### PR TITLE
Fixed small audio settings issue by setting default volumes in UIButt…

### DIFF
--- a/Assets/Scripts/UIScripts/UIButtonEvents.cs
+++ b/Assets/Scripts/UIScripts/UIButtonEvents.cs
@@ -74,6 +74,11 @@ public class UIButtonEvents : MonoBehaviour
         hasPushedEnter = false;
         volumeConfigs = new float[3];
 
+        //Janine - initialise to default volumes
+        volumeConfigs[0] = 1f;
+        volumeConfigs[1] = 0.75f;
+        volumeConfigs[2] = 1f;
+
         AudioManager.publicInstance.Instantiate();
         audioManager = GameObject.Find("AudioManager").GetComponent<AudioManager>();
 


### PR DESCRIPTION
…onEvents.

If the player started the game without a config.dat already there, clicks the settings, clicks save and then clicks settings again, the volumes will no longer be set to 0.